### PR TITLE
Prevent focused specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 coffeelint-jasmine
 ==================
 
-prevents you from committing tests annotation as iit, ddescribe, xit, xdescribe
+prevents you from committing tests annotation as `iit`, `ddescribe`, `xit`, `xdescribe`, `fit` and `fdescribe`.
 
 
 ## Installation

--- a/src/no_jasmine_annotations.coffee
+++ b/src/no_jasmine_annotations.coffee
@@ -12,5 +12,5 @@ module.exports = class NoJasmineAnnotations
 
     lintLine : (line, lineApi) ->
         tokens = line.trim().split(" ")
-        if tokens[0] in [ 'xit', 'iit', 'ddescribe', 'xdescribe' ]
+        if tokens[0] in [ 'xit', 'iit', 'fit', 'ddescribe', 'xdescribe', 'fdescribe' ]
             true


### PR DESCRIPTION
I have added two keywords: `fit` and `fdescribe`. These are [focused specs](http://jasmine.github.io/2.1/focused_specs.html). They faciltate development when you want to focus on particular tests, but they should not be commited to the repo. Linter should catch those.

Thank you!
